### PR TITLE
Ajout de <param name="wmode" value="transparent"> sur <object>

### DIFF
--- a/film.html
+++ b/film.html
@@ -7,5 +7,6 @@ title: Regarde le.
         <param name="movie" value="http://video.google.com/googleplayer.swf?docid=-3217190762343170150&amp;hl=fr&amp;fs=true" />
         <param name="allowFullScreen" value="true" />
         <param name="allowScriptAccess" value="always" />
+        <param name="wmode" value="transparent">
     </object>
 </section>


### PR DESCRIPTION
Pour que l'info bulle du rollover sur le btn +1 s'affiche devant la vidéo et non derrière.
